### PR TITLE
fix: OGP画像に描画内容を含める

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ export function App({ canvasId }: AppProps) {
   const [isInitialized, setIsInitialized] = useState(false);
   const [isLayerPanelOpen, setIsLayerPanelOpen] = useState(false);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [drawingCanvas, setDrawingCanvas] = useState<HTMLCanvasElement | null>(null);
 
   // Canvas origin tracking
   const canvasOriginRef = useRef<L.LatLng | null>(null);
@@ -151,12 +152,17 @@ export function App({ canvasId }: AppProps) {
   // Share handler
   const handleShare = useCallback(async () => {
     if (!canvas.canvas?.id || !mapPosition) return;
-    await share.share(canvas.canvas.id, mapPosition, { map: mapInstance });
-  }, [canvas.canvas?.id, mapPosition, share.share, mapInstance]);
+    await share.share(canvas.canvas.id, mapPosition, { map: mapInstance, drawingCanvas });
+  }, [canvas.canvas?.id, mapPosition, share.share, mapInstance, drawingCanvas]);
 
   // Map ready handler
   const handleMapReady = useCallback((map: L.Map) => {
     setMapInstance(map);
+  }, []);
+
+  // Canvas ready handler
+  const handleCanvasReady = useCallback((canvas: HTMLCanvasElement) => {
+    setDrawingCanvas(canvas);
   }, []);
 
   // Geolocation handler - move map to current position
@@ -301,6 +307,7 @@ export function App({ canvasId }: AppProps) {
         onStrokeEnd={handleStrokeEnd}
         onCanvasOriginInit={handleCanvasOriginInit}
         onMapReady={handleMapReady}
+        onCanvasReady={handleCanvasReady}
         tiles={canvas.tiles}
         canvasId={canvas.canvas?.id}
         onFlushSave={autoSave.flushSave}

--- a/frontend/src/components/MapWithDrawing/MapWithDrawing.tsx
+++ b/frontend/src/components/MapWithDrawing/MapWithDrawing.tsx
@@ -14,6 +14,7 @@ interface MapWithDrawingProps {
   onStrokeEnd?: (canvas: HTMLCanvasElement, bounds: L.LatLngBounds, zoom: number, strokeData?: StrokeData) => void;
   onCanvasOriginInit?: (origin: L.LatLng, zoom: number) => void;
   onMapReady?: (map: L.Map) => void;
+  onCanvasReady?: (canvas: HTMLCanvasElement) => void;
   tiles?: TileInfo[] | undefined;
   canvasId?: string | undefined;
   onFlushSave?: () => Promise<void>;
@@ -40,6 +41,7 @@ export function MapWithDrawing({
   onStrokeEnd,
   onCanvasOriginInit,
   onMapReady,
+  onCanvasReady,
   tiles,
   canvasId,
   onFlushSave,
@@ -348,6 +350,9 @@ export function MapWithDrawing({
 
     containerRef.current.appendChild(canvas);
     canvasRef.current = canvas;
+
+    // Notify parent that canvas is ready
+    onCanvasReady?.(canvas);
 
     // Sync canvas transform during pan
     const syncCanvasPan = () => {

--- a/frontend/src/hooks/useShare.ts
+++ b/frontend/src/hooks/useShare.ts
@@ -13,6 +13,8 @@ interface SharePosition {
 interface ShareOptions {
   /** Map instance for screenshot capture */
   map?: L.Map | null;
+  /** Drawing canvas element to include in screenshot */
+  drawingCanvas?: HTMLCanvasElement | null;
   /** Skip OGP preview generation (for testing or when map is unavailable) */
   skipPreview?: boolean;
 }
@@ -56,7 +58,7 @@ export function useShare(): UseShareReturn {
     position: SharePosition,
     options: ShareOptions = {}
   ) => {
-    const { map, skipPreview = false } = options;
+    const { map, drawingCanvas, skipPreview = false } = options;
 
     setIsSharing(true);
     setError(null);
@@ -72,8 +74,8 @@ export function useShare(): UseShareReturn {
         try {
           setProgress('プレビュー画像を生成中...');
 
-          // Capture map screenshot
-          const screenshot = await captureMapScreenshot(map);
+          // Capture map screenshot with drawing canvas overlay
+          const screenshot = await captureMapScreenshot(map, { drawingCanvas: drawingCanvas ?? null });
 
           if (screenshot) {
             setProgress('地名を取得中...');


### PR DESCRIPTION
## Summary

- OGP画像が白くなる問題を修正
- `leaflet-simple-map-screenshoter`は地図のみをキャプチャし、描画用Canvasは含まれていなかった
- 地図スクリーンショットに描画Canvasを合成する処理を追加

## 原因

`leaflet-simple-map-screenshoter`はLeafletの地図レイヤーのみをキャプチャします。描画用のHTML Canvasは別の要素としてオーバーレイされているため、スクリーンショットに含まれていませんでした。

## 修正内容

1. `MapWithDrawing`に`onCanvasReady`コールバックを追加
2. `App.tsx`で描画Canvasの参照を保持
3. `captureMapScreenshot`に`drawingCanvas`オプションを追加
4. `compositeMapAndCanvas`関数で地図と描画Canvasを合成

## Test plan

- [ ] 描画後にシェアボタンをタップ
- [ ] OGP画像に描画内容が含まれていることを確認
- [ ] SNSでシェアしてプレビューに絵が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)