### PR TITLE
fix: タイル保存の欠落とOGP画像の改善

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ export function App({ canvasId }: AppProps) {
   const [isInitialized, setIsInitialized] = useState(false);
   const [isLayerPanelOpen, setIsLayerPanelOpen] = useState(false);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [drawingCanvas, setDrawingCanvas] = useState<HTMLCanvasElement | null>(null);
 
   // Canvas origin tracking
   const canvasOriginRef = useRef<L.LatLng | null>(null);
@@ -153,6 +154,11 @@ export function App({ canvasId }: AppProps) {
     setMapInstance(map);
   }, []);
 
+  // Canvas ready handler
+  const handleCanvasReady = useCallback((canvas: HTMLCanvasElement) => {
+    setDrawingCanvas(canvas);
+  }, []);
+
   // Geolocation handler - move map to current position
   const handleGetLocation = useCallback(async () => {
     const position = await geolocation.getCurrentPosition();
@@ -175,10 +181,11 @@ export function App({ canvasId }: AppProps) {
     if (!canvas.canvas?.id || !mapPosition) return;
     await share.share(canvas.canvas.id, mapPosition, {
       map: mapInstance,
+      drawingCanvas,
       strokes: undoRedo.strokes,
       visibleLayerIds
     });
-  }, [canvas.canvas?.id, mapPosition, share.share, mapInstance, undoRedo.strokes, visibleLayerIds]);
+  }, [canvas.canvas?.id, mapPosition, share.share, mapInstance, drawingCanvas, undoRedo.strokes, visibleLayerIds]);
 
   // Handle map position changes
   const handlePositionChange = useCallback(
@@ -305,6 +312,7 @@ export function App({ canvasId }: AppProps) {
         onStrokeEnd={handleStrokeEnd}
         onCanvasOriginInit={handleCanvasOriginInit}
         onMapReady={handleMapReady}
+        onCanvasReady={handleCanvasReady}
         tiles={canvas.tiles}
         canvasId={canvas.canvas?.id}
         onFlushSave={autoSave.flushSave}

--- a/frontend/src/hooks/useShare.ts
+++ b/frontend/src/hooks/useShare.ts
@@ -14,7 +14,9 @@ interface SharePosition {
 interface ShareOptions {
   /** Map instance for screenshot capture */
   map?: L.Map | null;
-  /** Stroke data to include in screenshot */
+  /** Drawing canvas element containing saved tiles */
+  drawingCanvas?: HTMLCanvasElement | null;
+  /** Stroke data to include in screenshot (current session strokes) */
   strokes?: StrokeData[];
   /** Visible layer IDs to filter strokes */
   visibleLayerIds?: string[];
@@ -61,7 +63,7 @@ export function useShare(): UseShareReturn {
     position: SharePosition,
     options: ShareOptions = {}
   ) => {
-    const { map, strokes, visibleLayerIds, skipPreview = false } = options;
+    const { map, drawingCanvas, strokes, visibleLayerIds, skipPreview = false } = options;
 
     setIsSharing(true);
     setError(null);
@@ -77,8 +79,11 @@ export function useShare(): UseShareReturn {
         try {
           setProgress('プレビュー画像を生成中...');
 
-          // Capture map screenshot with strokes overlay
+          // Capture map screenshot with drawing canvas and strokes overlay
           const screenshotOptions: Parameters<typeof captureMapScreenshot>[1] = {};
+          if (drawingCanvas) {
+            screenshotOptions.drawingCanvas = drawingCanvas;
+          }
           if (strokes) {
             screenshotOptions.strokes = strokes;
           }


### PR DESCRIPTION
## Summary
- タイル保存のデバウンスによる欠落（歯抜け）を修正
- OGP画像にdrawingCanvasを含めるよう改善

## 問題1: タイル保存の欠落
`useAutoSave`のデバウンスが早期のストロークを上書きしていた。

**原因:**
```javascript
// 新しい保存が来ると前の保存をキャンセル
cancelSave();
pendingSaveFnRef.current = saveFn;  // 上書き
```

**修正:**
- 保存関数をキューに追加
- デバウンス後に全ての保存関数を順次実行

## 問題2: OGP画像の不完全
ページリロード後、`undoRedo.strokes`が空になるため、OGPが不完全だった。

**修正:**
- OGP生成時に`drawingCanvas`（R2タイル）も含める
- 合成順序: マップ背景 → drawingCanvas → strokes

## Test plan
- [x] ビルド成功
- [x] 全171テスト通過
- [ ] 実際の描画で歯抜けが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)