### PR TITLE
fix: Reset canvas transform when drawing starts after pan

### DIFF
--- a/frontend/src/components/MapWithDrawing/MapWithDrawing.tsx
+++ b/frontend/src/components/MapWithDrawing/MapWithDrawing.tsx
@@ -767,12 +767,18 @@ export function MapWithDrawing({
             return;
           }
 
-          // Ensure canvas is visible before drawing
-          if (canvasRef.current && canvasRef.current.style.opacity !== '1') {
-            canvasRef.current.style.opacity = '1';
-            canvasRef.current.style.transform = '';
-            canvasRef.current.style.transformOrigin = '';
-            void logDebug('globalTouchStart_FORCE_SHOW_CANVAS', { version: BUILD_VERSION });
+          // Ensure canvas is visible and properly positioned before drawing
+          if (canvasRef.current) {
+            const needsReset = canvasRef.current.style.opacity !== '1' || canvasRef.current.style.transform !== '';
+            if (needsReset) {
+              canvasRef.current.style.opacity = '1';
+              canvasRef.current.style.transform = '';
+              canvasRef.current.style.transformOrigin = '';
+              void logDebug('globalTouchStart_FORCE_RESET_CANVAS', {
+                version: BUILD_VERSION,
+                reason: canvasRef.current.style.opacity !== '1' ? 'opacity' : 'transform',
+              });
+            }
           }
 
           void logDebug('globalTouchStart_DRAW_START', {
@@ -832,12 +838,18 @@ export function MapWithDrawing({
         if (touch && isDrawableZoom) {
           const point = getTouchPoint(touch);
           if (point) {
-            // Ensure canvas is visible before drawing
-            if (canvasRef.current && canvasRef.current.style.opacity !== '1') {
-              canvasRef.current.style.opacity = '1';
-              canvasRef.current.style.transform = '';
-              canvasRef.current.style.transformOrigin = '';
-              void logDebug('globalTouchMove_FORCE_SHOW_CANVAS', { version: BUILD_VERSION });
+            // Ensure canvas is visible and properly positioned before drawing
+            if (canvasRef.current) {
+              const needsReset = canvasRef.current.style.opacity !== '1' || canvasRef.current.style.transform !== '';
+              if (needsReset) {
+                canvasRef.current.style.opacity = '1';
+                canvasRef.current.style.transform = '';
+                canvasRef.current.style.transformOrigin = '';
+                void logDebug('globalTouchMove_FORCE_RESET_CANVAS', {
+                  version: BUILD_VERSION,
+                  reason: canvasRef.current.style.opacity !== '1' ? 'opacity' : 'transform',
+                });
+              }
             }
 
             void logDebug('globalTouchMove_IMMEDIATE_START', {


### PR DESCRIPTION
## Summary
- 2本指ドラッグ後に描画が表示されない問題を修正
- 描画開始時にキャンバスのtransformもリセットするように変更

## Changes
- Previously only reset canvas when opacity was not '1'
- Now also reset when transform is applied (after pan)

## Test
1. 描画
2. 2本指でドラッグ（ズームなし）
3. 再度描画 → 表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)